### PR TITLE
feat: implement QueryClient with Utxos set of functions

### DIFF
--- a/examples/follow-tip.ts
+++ b/examples/follow-tip.ts
@@ -4,16 +4,16 @@ async function test() {
   let client = new CardanoSyncClient({
     uri: "http://localhost:50051",
   });
-
+  
   let tip = client.followTip([
     {
       slot: 54131816,
       hash: "34c65aba4b299113a488b74e2efe3a3dd272d25b470d25f374b2c693d4386535",
-    },
+    }
   ]);
 
   for await (const event of tip) {
-    console.log(event);
+    console.log((event as any).block.header.slot);
   }
 }
 test().catch(console.error);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utxorpc/sdk",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A client library to interact with UTxO RPC compliant endpoints",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,11 +9,14 @@ import * as Cardano from "@utxorpc/spec/lib/utxorpc/v1alpha/cardano/cardano_pb.j
 
 import { SyncService } from "@utxorpc/spec/lib/utxorpc/v1alpha/sync/sync_connect.js";
 
+import { QueryService } from "@utxorpc/spec/lib/utxorpc/v1alpha/query/query_connect.js";
+
 import {
   AnyChainBlock,
   BlockRef,
   FollowTipRequest,
 } from "@utxorpc/spec/lib/utxorpc/v1alpha/sync/sync_pb.js";
+import { AnyUtxoData, SearchUtxosResponse } from "@utxorpc/spec/lib/utxorpc/v1alpha/query/query_pb.js";
 
 function metadataInterceptor(options?: ClientBuilderOptions): Interceptor {
   return (next) => async (req) => {
@@ -27,10 +30,11 @@ function metadataInterceptor(options?: ClientBuilderOptions): Interceptor {
   };
 }
 
-interface Chain<BlockT, PointT> {
+interface Chain<BlockT, PointT, UTxOT> {
   anyChainToBlock(msg: AnyChainBlock): BlockT | null;
   pointToBlockRef(p: PointT): BlockRef;
   blockRefToPoint(r: BlockRef): PointT;
+  anyUtxoToUnspentOutput(u: AnyUtxoData): UTxOT | null;
 }
 
 export type TipEvent<BlockT, PointT> =
@@ -43,13 +47,14 @@ export type ClientBuilderOptions = {
   headers?: Record<string, string>;
 };
 
-export class SyncClient<BlockT, PointT> {
+export class SyncClient<BlockT, PointT, UTxOT> {
   inner: PromiseClient<typeof SyncService>;
-  chain: Chain<BlockT, PointT>;
+  queryClient: PromiseClient<typeof QueryService>;
+  chain: Chain<BlockT, PointT, UTxOT>;
 
-  constructor(options: ClientBuilderOptions, chain: Chain<BlockT, PointT>) {
+  constructor(options: ClientBuilderOptions, chain: Chain<BlockT, PointT, UTxOT>) {
     let headerInterceptor = metadataInterceptor(options);
-    
+
     const transport = createGrpcTransport({
       httpVersion: "2",
       baseUrl: options.uri,
@@ -57,6 +62,7 @@ export class SyncClient<BlockT, PointT> {
     });
 
     this.inner = createPromiseClient(SyncService, transport);
+    this.queryClient = createPromiseClient(QueryService, transport);
     this.chain = chain;
   }
 
@@ -91,13 +97,120 @@ export class SyncClient<BlockT, PointT> {
       }
     }
   }
+
+  async fetchBlock(p: PointT): Promise<BlockT> {
+    const req = this.chain.pointToBlockRef(p);
+    const res = await this.inner.fetchBlock({ ref: [req] });
+    return this.chain.anyChainToBlock(res.block[0])!;
+  }
+}
+
+export class QueryClient<BlockT, PointT, UTxOT> {
+  inner: PromiseClient<typeof QueryService>;
+  chain: Chain<BlockT, PointT, UTxOT>;
+
+  constructor(options: ClientBuilderOptions, chain: Chain<BlockT, PointT, UTxOT>) {
+    let headerInterceptor = metadataInterceptor(options);
+
+    const transport = createGrpcTransport({
+      httpVersion: "2",
+      baseUrl: options.uri,
+      interceptors: [headerInterceptor],
+    });
+
+    this.inner = createPromiseClient(QueryService, transport);
+    this.chain = chain;
+  }
+
+  async getUtxoByOutputRef(refs: {txHash: Uint8Array, outputIndex: number}[]): Promise<UTxOT[] | null> {
+    const searchResponse = await this.inner.readUtxos({
+      keys: refs.map((ref) => {
+        return {
+          hash: ref.txHash,
+          index: ref.outputIndex
+        };
+      })
+    });
+
+    return searchResponse.items.map((item) => {
+      return this.chain.anyUtxoToUnspentOutput(item);
+    }).filter((item) => item != null) as UTxOT[];
+  }
+
+  async getUtxosByAddress(address: Uint8Array): Promise<UTxOT[]> {
+    const searchResponse = await this.inner.searchUtxos({
+      predicate: {
+        match: {
+          utxoPattern: {
+            value: {
+              address: {
+                exactAddress: address
+              }
+            },
+            case: "cardano"
+          }
+        }
+      }
+    });
+
+    return searchResponse.items.map((item) => {
+      return this.chain.anyUtxoToUnspentOutput(item);
+    }).filter((item) => item != null) as UTxOT[];
+  }
+
+  async getUtxosByAddressAsset(address: Uint8Array, policyId: Uint8Array, assetName: Uint8Array): Promise<UTxOT[]> {
+    const searchResponse = await this.inner.searchUtxos({
+      predicate: {
+        match: {
+          utxoPattern: {
+            value: {
+              asset: {
+                policyId,
+                // assetName - commented because currently dolos returns conflicting criteria when both assetName and policyId are set
+              },
+              address: {
+                exactAddress: address
+              }
+            },
+            case: "cardano"
+          }
+        }
+      }
+    });
+
+    return searchResponse.items.map((item) => {
+      return this.chain.anyUtxoToUnspentOutput(item);
+    }).filter((item) => item != null) as UTxOT[];
+  }
+
+  async getUtxosByNft(policyId: Uint8Array, assetName: Uint8Array): Promise<UTxOT[]> {
+    const searchResponse = await this.inner.searchUtxos({
+      predicate: {
+        match: {
+          utxoPattern: {
+            value: {
+              asset: {
+                policyId,
+                // assetName - commented because currently dolos returns conflicting criteria when both assetName and policyId are set
+              }
+            },
+            case: "cardano"
+          }
+        }
+      }
+    });
+
+    return searchResponse.items.map((item) => {
+      return this.chain.anyUtxoToUnspentOutput(item);
+    }).filter((item) => item != null) as UTxOT[];
+  }
 }
 
 export type CardanoBlock = Cardano.Block;
-
 export type CardanoPoint = { slot: number | string; hash: string };
+export type CardanoUnspentOutput = Cardano.TxInput;
 
-const CARDANO: Chain<CardanoBlock, CardanoPoint> = {
+const CARDANO: Chain<CardanoBlock, CardanoPoint, CardanoUnspentOutput> = {
   anyChainToBlock(msg) {
     return msg.chain.case == "cardano" ? msg.chain.value : null;
   },
@@ -113,9 +226,22 @@ const CARDANO: Chain<CardanoBlock, CardanoPoint> = {
       hash: Buffer.from(r.hash).toString("hex"),
     };
   },
+  anyUtxoToUnspentOutput(u) {
+    return u.parsedState.case == "cardano" ? {
+      txHash: u.txoRef?.hash,
+      outputIndex: u.txoRef?.index,
+      asOutput: u.parsedState.value
+    } as CardanoUnspentOutput : null;
+  }
 };
 
-export class CardanoSyncClient extends SyncClient<CardanoBlock, CardanoPoint> {
+export class CardanoSyncClient extends SyncClient<CardanoBlock, CardanoPoint, CardanoUnspentOutput> {
+  constructor(options: ClientBuilderOptions) {
+    super(options, CARDANO);
+  }
+}
+
+export class CardanoQueryClient extends QueryClient<CardanoBlock, CardanoPoint, CardanoUnspentOutput> {
   constructor(options: ClientBuilderOptions) {
     super(options, CARDANO);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,7 @@ export class QueryClient<BlockT, PointT, UTxOT> {
     this.chain = chain;
   }
 
-  async getUtxoByOutputRef(refs: {txHash: Uint8Array, outputIndex: number}[]): Promise<UTxOT[] | null> {
+  async readUtxosByOutputRef(refs: {txHash: Uint8Array, outputIndex: number}[]): Promise<UTxOT[]> {
     const searchResponse = await this.inner.readUtxos({
       keys: refs.map((ref) => {
         return {
@@ -137,7 +137,7 @@ export class QueryClient<BlockT, PointT, UTxOT> {
     }).filter((item) => item != null) as UTxOT[];
   }
 
-  async getUtxosByAddress(address: Uint8Array): Promise<UTxOT[]> {
+  async searchUtxosByAddress(address: Uint8Array): Promise<UTxOT[]> {
     const searchResponse = await this.inner.searchUtxos({
       predicate: {
         match: {
@@ -158,7 +158,12 @@ export class QueryClient<BlockT, PointT, UTxOT> {
     }).filter((item) => item != null) as UTxOT[];
   }
 
-  async getUtxosByAddressAsset(address: Uint8Array, policyId: Uint8Array, assetName: Uint8Array): Promise<UTxOT[]> {
+  async searchUtxosByAddressAsset(address: Uint8Array, policyId?: Uint8Array, unit?: Uint8Array): Promise<UTxOT[]> {
+
+    if ((policyId && unit) || (!policyId && !unit)) {
+      throw new Error("Exactly one of policyId or assetName must be provided.");
+    }
+
     const searchResponse = await this.inner.searchUtxos({
       predicate: {
         match: {
@@ -166,7 +171,7 @@ export class QueryClient<BlockT, PointT, UTxOT> {
             value: {
               asset: {
                 policyId,
-                // assetName - commented because currently dolos returns conflicting criteria when both assetName and policyId are set
+                assetName: unit
               },
               address: {
                 exactAddress: address
@@ -183,7 +188,12 @@ export class QueryClient<BlockT, PointT, UTxOT> {
     }).filter((item) => item != null) as UTxOT[];
   }
 
-  async getUtxosByNft(policyId: Uint8Array, assetName: Uint8Array): Promise<UTxOT[]> {
+  async searchUtxosByAsset(policyId?: Uint8Array, unit?: Uint8Array): Promise<UTxOT[]> {
+
+    if ((policyId && unit) || (!policyId && !unit)) {
+      throw new Error("Exactly one of policyId or assetName must be provided.");
+    }
+
     const searchResponse = await this.inner.searchUtxos({
       predicate: {
         match: {
@@ -191,7 +201,7 @@ export class QueryClient<BlockT, PointT, UTxOT> {
             value: {
               asset: {
                 policyId,
-                // assetName - commented because currently dolos returns conflicting criteria when both assetName and policyId are set
+                assetName: unit
               }
             },
             case: "cardano"

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,7 @@ export class QueryClient<BlockT, PointT, UTxOT> {
     this.chain = chain;
   }
 
-  async readUtxosByOutputRef(refs: {txHash: Uint8Array, outputIndex: number}[]): Promise<UTxOT[]> {
+  async readUtxosByOutputRef(refs: { txHash: Uint8Array, outputIndex: number }[]): Promise<UTxOT[]> {
     const searchResponse = await this.inner.readUtxos({
       keys: refs.map((ref) => {
         return {
@@ -164,15 +164,16 @@ export class QueryClient<BlockT, PointT, UTxOT> {
       throw new Error("Exactly one of policyId or assetName must be provided.");
     }
 
+    const predicate = policyId
+      ? { policyId }
+      : { assetName: unit };
+
     const searchResponse = await this.inner.searchUtxos({
       predicate: {
         match: {
           utxoPattern: {
             value: {
-              asset: {
-                policyId,
-                assetName: unit
-              },
+              asset: predicate,
               address: {
                 exactAddress: address
               }
@@ -194,15 +195,16 @@ export class QueryClient<BlockT, PointT, UTxOT> {
       throw new Error("Exactly one of policyId or assetName must be provided.");
     }
 
+    const predicate = policyId
+      ? { policyId }
+      : { assetName: unit };
+
     const searchResponse = await this.inner.searchUtxos({
       predicate: {
         match: {
           utxoPattern: {
             value: {
-              asset: {
-                policyId,
-                assetName: unit
-              }
+              asset: predicate
             },
             case: "cardano"
           }


### PR DESCRIPTION
This PR implements a basic `QueryClient` to encapsulate the QueryService gRPC function calls.

the following functions are implemented:

```
- readUtxosByOutputRef
- searchUtxosByAddress
- searchUtxosByAddressAsset
- searchUtxosByAsset
```