### PR TITLE
fix: for node js esm build to not bundle anymore

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -41,8 +41,7 @@ export default defineConfig((options) => {
                 options.mainFields = ['module', 'main']
             }
         },
-        noExternal: ['@connectrpc/connect', '@connectrpc/connect-web', '@connectrpc/connect-node'],
-        treeshake: true,
+        noExternal: isBrowser ? ['@connectrpc/connect', '@connectrpc/connect-web', '@connectrpc/connect-node'] : [],
         sourcemap: true,
         tsconfig: path.resolve(rootDir, 'tsconfig.json'),
     }


### PR DESCRIPTION
This PR adjust the tsup config so that for NodeJS esm build it will not bundle the javascript dependencies anymore