### PR TITLE
feat: add evalTx function to SubmitClient and update spec dependecy version to `0.14.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@connectrpc/connect-node": "1.4",
     "@connectrpc/connect-web": "1.4",
     "@types/node": "20.14.10",
-    "@utxorpc/spec": "0.12.0",
+    "@utxorpc/spec": "0.14.0",
     "buffer": "^6.0.3"
   },
   "exports": {

--- a/src/cardano.ts
+++ b/src/cardano.ts
@@ -316,7 +316,7 @@ export class SubmitClient {
   async evalTx(tx: TxCbor): Promise<submit.EvalTxResponse> {
     const res = await this.inner.evalTx({
       tx: [tx].map((cbor) => ({ type: { case: "raw", value: cbor } })),
-    })
+    });
     
     return res;
   }

--- a/src/cardano.ts
+++ b/src/cardano.ts
@@ -313,6 +313,14 @@ export class SubmitClient {
     return res.ref[0];
   }
 
+  async evalTx(tx: TxCbor): Promise<submit.EvalTxResponse> {
+    const res = await this.inner.evalTx({
+      tx: [tx].map((cbor) => ({ type: { case: "raw", value: cbor } })),
+    })
+    
+    return res;
+  }
+
   async *waitForTx(txHash: TxHash): AsyncIterable<submit.Stage> {
     const updates = this.inner.waitForTx({
       ref: [txHash],


### PR DESCRIPTION
This updates utxorpc-spec version dependency to version 0.14.0.
This also implements the evalTx function for the U5C provider to use.