### PR TITLE
fix(DumpHistoryRequest): allow fetching from genesis

### DIFF
--- a/src/cardano.ts
+++ b/src/cardano.ts
@@ -152,12 +152,12 @@ export class SyncClient {
     return anyChainToBlock(res.block[0])!;
   }
 
-  async fetchHistory(p: ChainPoint, maxItems = 1): Promise<cardano.Block> {
+  async fetchHistory(p: ChainPoint | undefined, maxItems = 1): Promise<cardano.Block> {
     const req = new sync.DumpHistoryRequest({
-      startToken: new sync.BlockRef({
+      startToken: p ? new sync.BlockRef({
         index: BigInt(p.slot),
         hash: Buffer.from(p.hash, "hex"),
-      }),
+      }) : undefined,
       maxItems: maxItems,
     });
 


### PR DESCRIPTION
For utxorpc, `startToken` is optional and, if omitted, will fetch history starting from the genesis block

However, the typescript SDK accidentally made this a required field

You can test this yourself if you want to verify the behavior when `startToken` is omitted with the following query

```bash
grpcurl -plaintext -d '{
    "maxItems": 3
}' localhost:50051 utxorpc.v1alpha.sync.SyncService.DumpHistory
```