### PR TITLE
chore(deps): bump @utxorpc/spec to 0.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@connectrpc/connect": "1.4",
     "@connectrpc/connect-node": "1.4",
     "@connectrpc/connect-web": "1.4",
-    "@utxorpc/spec": "0.18.1",
+    "@utxorpc/spec": "0.19.0",
     "buffer": "^6.0.3"
   },
   "exports": {


### PR DESCRIPTION
Brings node-sdk current with the `spec/` **v0.19.0** pin.

node-sdk was held at `@utxorpc/spec@0.18.1` only because 0.19.0 was not published to npm. It is now `latest` on npm — the first release via OIDC trusted publishing — so the bump is unblocked.

- `package.json`: `@utxorpc/spec` `0.18.1` → `0.19.0` (exact pin, matching existing style)
- Build verified locally: `npm run build` succeeds for both node and browser targets against 0.19.0.
- No lockfile change — this project does not commit `package-lock.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)